### PR TITLE
Added overshoot and undershoot check to bilinear_least_squares.cc

### DIFF
--- a/include/aspect/particle/interpolator/bilinear_least_squares_discontinuous.h
+++ b/include/aspect/particle/interpolator/bilinear_least_squares_discontinuous.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _aspect_particle_interpolator_bilinear_least_squares_h
-#define _aspect_particle_interpolator_bilinear_least_squares_h
+#ifndef _aspect_particle_interpolator_bilinear_least_squares_discontinuous_h
+#define _aspect_particle_interpolator_bilinear_least_squares_discontinuous_h
 
 #include <aspect/particle/interpolator/interface.h>
 #include <aspect/simulator_access.h>
@@ -37,7 +37,7 @@ namespace aspect
        * @ingroup ParticleInterpolators
        */
       template <int dim>
-      class BilinearLeastSquares : public Interface<dim>, public aspect::SimulatorAccess<dim>
+      class BilinearLeastSquaresDiscontinuous : public Interface<dim>, public aspect::SimulatorAccess<dim>
       {
         public:
           /**
@@ -45,7 +45,7 @@ namespace aspect
            */
           virtual
           std::vector<std::vector<double> >
-          properties_at_points(const ParticleHandler<dim> &particle_handler,
+          properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
                                const std::vector<Point<dim> > &positions,
                                const ComponentMask &selected_properties,
                                const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const;
@@ -74,7 +74,7 @@ namespace aspect
            * and global min for each propery.
            */
           bool use_global_valued_limiter;
-          bool check_for_overshoot_and_undershoot;
+
           /**
            * For each interpolated particle property, a global max and global
            * min are stored as elements of vectors.

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -142,7 +142,17 @@ namespace aspect
                                         c[1]*(support_point[0] - approximated_cell_midpoint[0])/cell_diameter +
                                         c[2]*(support_point[1] - approximated_cell_midpoint[1])/cell_diameter +
                                         c[3]*(support_point[0] - approximated_cell_midpoint[0])*(support_point[1] - approximated_cell_midpoint[1])/std::pow(cell_diameter,2);
+                
 
+            // Trigger an assert statement if there is overshoot or undershoot.
+            if (check_for_overshoot_and_undershoot)
+            {
+                AssertThrow(interpolated_value >= global_minimum_particle_properties[property_index] &&
+                            interpolated_value <= global_maximum_particle_properties[property_index],
+                            ExcMessage("Overshoot or undershoot detected"));
+            }
+            
+ 
             // Overshoot and undershoot correction of interpolated particle property.
             if (use_global_valued_limiter)
               {
@@ -185,7 +195,10 @@ namespace aspect
                                   Patterns::Bool (),
                                   "Whether to apply a global particle property limiting scheme to the interpolated "
                                   "particle properties.");
-
+               
+                prm.declare_entry("Check for overshoot and undershoot", "false",
+                                  Patterns::Bool (),
+                                  "Whether to trigger an assert statement if there is overshoot or undershoot.");
               }
               prm.leave_subsection();
             }
@@ -209,7 +222,9 @@ namespace aspect
               prm.enter_subsection("Bilinear least squares");
               {
                 use_global_valued_limiter = prm.get_bool("Use limiter");
-                if (use_global_valued_limiter)
+                check_for_overshoot_and_undershoot = prm.get_bool("Check for overshoot and undershoot");
+
+                if (use_global_valued_limiter || check_for_overshoot_and_undershoot)
                   {
                     global_maximum_particle_properties = Utilities::string_to_double(Utilities::split_string_list(prm.get("Global particle property maximum")));
                     global_minimum_particle_properties = Utilities::string_to_double(Utilities::split_string_list(prm.get("Global particle property minimum")));


### PR DESCRIPTION
An overshoot and undershoot check can now be performed when using the bilinear interpolation scheme by setting the parameter "Check for overshoot and undershoot" = true in the subsection Particles/Interpolator/Bilinear least squares